### PR TITLE
Separate the drop column and rename column to different files

### DIFF
--- a/src/test/resources/dlabs-schema/V5__Move_execution_summary_data_as_list.sql
+++ b/src/test/resources/dlabs-schema/V5__Move_execution_summary_data_as_list.sql
@@ -5,6 +5,3 @@ UPDATE ddemo_session_step_info SET new_data = jsonb_build_array(data);
 
 ALTER TABLE ddemo_session_step_info
 DROP COLUMN data;
-
-ALTER TABLE ddemo_session_step_info
-RENAME COLUMN new_data TO data;

--- a/src/test/resources/dlabs-schema/V6__Rename_column_new_data_to_data.sql
+++ b/src/test/resources/dlabs-schema/V6__Rename_column_new_data_to_data.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ddemo_session_step_info
+RENAME COLUMN new_data TO data;


### PR DESCRIPTION
The V5 sql file was creating an error because `Drop column data` and `ALTER TABLE ddemo_session_step_info
RENAME COLUMN new_data TO data;` were executing in the same transaction block, leading to the error message `column data already exists`.